### PR TITLE
Platform/iMX: drop DefaultExceptionHandlerLibBase reference

### DIFF
--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -202,7 +202,6 @@
   PlatformPeiLib|ArmPlatformPkg/PlatformPei/PlatformPeiLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
-  DefaultExceptionHandlerLib|ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLibBase.inf
 
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
@@ -226,7 +226,6 @@
   PlatformPeiLib|ArmPlatformPkg/PlatformPei/PlatformPeiLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
-  DefaultExceptionHandlerLib|ArmPkg/Library/DefaultExceptionHandlerLib/DefaultExceptionHandlerLibBase.inf
 
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf


### PR DESCRIPTION
Dropping reference to DefaultExceptionHandlerLibBase from i.MX
packages.

From https://github.com/tianocore/edk2-platforms/commit/ca70cbbcc0001417cbe8b209fe196e7b9ef442b9
Now that DebugAgentSymbolsBaseLib from ArmPkg no longer requires
a DefaultExceptionHandlerLib resolution, drop the overrides from
the [LibraryClasses.SEC] sections of various platforms.