### PR TITLE
iMX7Pkg: LcdifGop: change failing assert to warning

### DIFF
--- a/Silicon/NXP/iMX7Pkg/Drivers/LcdifGop/LcdifBoard.c
+++ b/Silicon/NXP/iMX7Pkg/Drivers/LcdifGop/LcdifBoard.c
@@ -120,6 +120,11 @@ VOID LcdifBoardInitialize ()
     RETURN_STATUS status;
 
     //
+    // Dummy read since first read returns garbage
+    //
+    iMXI2cRead(&i2c4SIL164Config, SIL164_REG_VND_IDL, &i2cData, 1);
+
+    //
     // Sanity check to make sure we are attached to a SIL164 chip.
     // Reading one byte at a time as SIL164 support only byte read and write.
     //


### PR DESCRIPTION
The LcdifGop initialization code reads device identification registers from
the SIL164, and ASSERT's that they match what is expected.
It looks like the first I2C transaction returns garbage data, so the
first ASSERT is failing, which causes boot to stop. Subsequent reads
return the expected values. Change the ASSERT to a warning since
the failure is not critical.

Fixes #10 