### PR TITLE
iMX: add SerCx-FriendlyName property to UART device nodes

### DIFF
--- a/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -73,10 +73,10 @@ Device (UAR1)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -140,10 +140,10 @@ Device (UAR2)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -205,10 +205,10 @@ Device (UAR3)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }
@@ -293,10 +293,10 @@ Device (UAR4)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART4"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART4"}
       }
   })
 }
@@ -386,10 +386,10 @@ Device (UAR5)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART5"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART5"}
       }
   })
 }

--- a/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -72,6 +72,13 @@ Device (UAR1)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -132,6 +139,13 @@ Device (UAR2)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -189,6 +203,13 @@ Device (UAR3)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 
@@ -270,6 +291,13 @@ Device (UAR4)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART4"}
+      }
   })
 }
 
@@ -356,5 +384,12 @@ Device (UAR5)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART5"}
+      }
   })
 }

--- a/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -72,6 +72,13 @@ Device (UAR1)
         })
         Return(RBUF)
     }
+
+    Name(_DSD, Package() {
+        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package() {
+                Package(2) {"SerCx-FriendlyName", "UART1"}
+            }
+    })
 }
 
 Device (UAR2)
@@ -133,5 +140,12 @@ Device (UAR2)
         })
         Return(RBUF)
     }
+
+    Name(_DSD, Package() {
+        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package() {
+                Package(2) {"SerCx-FriendlyName", "UART2"}
+            }
+    })
 }
 

--- a/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -73,10 +73,10 @@ Device (UAR1)
         Return(RBUF)
     }
 
-    Name(_DSD, Package() {
-        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-            Package() {
-                Package(2) {"SerCx-FriendlyName", "UART1"}
+    Name (_DSD, Package () {
+        ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package (2) {"SerCx-FriendlyName", "UART1"}
             }
     })
 }
@@ -141,10 +141,10 @@ Device (UAR2)
         Return(RBUF)
     }
 
-    Name(_DSD, Package() {
-        ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-            Package() {
-                Package(2) {"SerCx-FriendlyName", "UART2"}
+    Name (_DSD, Package () {
+        ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+            Package () {
+                Package (2) {"SerCx-FriendlyName", "UART2"}
             }
     })
 }

--- a/Platform/Compulab/ClSomImx7_iMX7D_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Compulab/ClSomImx7_iMX7D_1GB/AcpiTables/Dsdt-Uart.asl
@@ -45,6 +45,13 @@ Device (UAR1)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -99,6 +106,13 @@ Device (UAR2)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
   })
 }
 
@@ -170,6 +184,13 @@ Device (UAR4)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART4"}
+      }
+  })
 }
 
 // UART1 in CL_SOM_iMX7 schematic
@@ -225,6 +246,13 @@ Device (UAR5)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART5"}
+      }
   })
 }
 
@@ -294,5 +322,12 @@ Device (UAR7)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART7"}
+      }
   })
 }

--- a/Platform/Compulab/ClSomImx7_iMX7D_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Compulab/ClSomImx7_iMX7D_1GB/AcpiTables/Dsdt-Uart.asl
@@ -46,10 +46,10 @@ Device (UAR1)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -108,10 +108,10 @@ Device (UAR2)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -185,10 +185,10 @@ Device (UAR4)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART4"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART4"}
       }
   })
 }
@@ -248,10 +248,10 @@ Device (UAR5)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART5"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART5"}
       }
   })
 }
@@ -324,10 +324,10 @@ Device (UAR7)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART7"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART7"}
       }
   })
 }

--- a/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Uart.asl
@@ -73,10 +73,10 @@ Device (UAR1)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -245,10 +245,10 @@ Device (UAR4)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART4"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART4"}
       }
   })
 }
@@ -313,10 +313,10 @@ Device (UAR5)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART5"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART5"}
       }
   })
 }

--- a/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Uart.asl
@@ -72,6 +72,13 @@ Device (UAR1)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -148,6 +155,13 @@ Device (UAR3)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 
@@ -230,6 +244,13 @@ Device (UAR4)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART4"}
+      }
+  })
 }
 
 Device (UAR5)
@@ -290,5 +311,12 @@ Device (UAR5)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART5"}
+      }
   })
 }

--- a/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -73,10 +73,10 @@ Device (UAR1)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -157,10 +157,10 @@ Device (UAR3)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }
@@ -245,10 +245,10 @@ Device (UAR4)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART4"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART4"}
       }
   })
 }
@@ -313,10 +313,10 @@ Device (UAR5)
     )
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART5"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART5"}
       }
   })
 }

--- a/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -72,6 +72,13 @@ Device (UAR1)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -148,6 +155,13 @@ Device (UAR3)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 
@@ -230,6 +244,13 @@ Device (UAR4)
       ,
     )
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART4"}
+      }
+  })
 }
 
 Device (UAR5)
@@ -290,5 +311,12 @@ Device (UAR5)
       ResourceConsumer,
       ,
     )
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART5"}
+      }
   })
 }

--- a/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Uart.asl
@@ -64,6 +64,13 @@ Device (UAR1)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -118,6 +125,13 @@ Device (UAR2)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -169,6 +183,13 @@ Device (UAR3)
       0,
       ResourceConsumer,
       ,)
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 

--- a/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Uart.asl
@@ -65,10 +65,10 @@ Device (UAR1)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -126,10 +126,10 @@ Device (UAR2)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -185,10 +185,10 @@ Device (UAR3)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }

--- a/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Uart.asl
@@ -70,10 +70,10 @@ Device (UAR1)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -136,10 +136,10 @@ Device (UAR2)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -200,10 +200,10 @@ Device (UAR3)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }

--- a/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Uart.asl
@@ -69,6 +69,13 @@ Device (UAR1)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -128,6 +135,13 @@ Device (UAR2)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -184,6 +198,13 @@ Device (UAR3)
       0,
       ResourceConsumer,
       ,)
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 

--- a/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Uart.asl
@@ -70,10 +70,10 @@ Device (UAR1)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -136,10 +136,10 @@ Device (UAR2)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -200,10 +200,10 @@ Device (UAR3)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }

--- a/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Uart.asl
@@ -69,6 +69,13 @@ Device (UAR1)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -128,6 +135,13 @@ Device (UAR2)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -184,6 +198,13 @@ Device (UAR3)
       0,
       ResourceConsumer,
       ,)
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 

--- a/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Uart.asl
@@ -64,6 +64,13 @@ Device (UAR1)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -118,6 +125,13 @@ Device (UAR2)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -169,6 +183,13 @@ Device (UAR3)
       0,
       ResourceConsumer,
       ,)
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 

--- a/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Uart.asl
@@ -65,10 +65,10 @@ Device (UAR1)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -126,10 +126,10 @@ Device (UAR2)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -185,10 +185,10 @@ Device (UAR3)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }

--- a/Platform/Udoo/UdooNeo_iMX6SX_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Udoo/UdooNeo_iMX6SX_1GB/AcpiTables/Dsdt-Uart.asl
@@ -64,6 +64,13 @@ Device (UAR1)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART1"}
+      }
+  })
 }
 
 Device (UAR2)
@@ -118,6 +125,13 @@ Device (UAR2)
       ResourceConsumer,
       ,)
   })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART2"}
+      }
+  })
 }
 
 Device (UAR3)
@@ -169,6 +183,13 @@ Device (UAR3)
       0,
       ResourceConsumer,
       ,)
+  })
+
+  Name(_DSD, Package() {
+    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package() {
+        Package(2) {"SerCx-FriendlyName", "UART3"}
+      }
   })
 }
 

--- a/Platform/Udoo/UdooNeo_iMX6SX_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/Udoo/UdooNeo_iMX6SX_1GB/AcpiTables/Dsdt-Uart.asl
@@ -65,10 +65,10 @@ Device (UAR1)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART1"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART1"}
       }
   })
 }
@@ -126,10 +126,10 @@ Device (UAR2)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART2"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART2"}
       }
   })
 }
@@ -185,10 +185,10 @@ Device (UAR3)
       ,)
   })
 
-  Name(_DSD, Package() {
-    ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-      Package() {
-        Package(2) {"SerCx-FriendlyName", "UART3"}
+  Name (_DSD, Package () {
+    ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"SerCx-FriendlyName", "UART3"}
       }
   })
 }

--- a/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -53,6 +53,7 @@ Device (UAR1)
     ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
     Package() {
       Package (2) { "dte-mode", 1 },
+      Package(2) {"SerCx-FriendlyName", "UART1"}
     }
   })
 }

--- a/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
+++ b/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Uart.asl
@@ -51,9 +51,9 @@ Device (UAR1)
 
   Name (_DSD, Package() {
     ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
-    Package() {
+    Package () {
       Package (2) { "dte-mode", 1 },
-      Package(2) {"SerCx-FriendlyName", "UART1"}
+      Package (2) {"SerCx-FriendlyName", "UART1"}
     }
   })
 }


### PR DESCRIPTION
In 19H1, SerCx is adding support to create device interfaces. This behavior
must be opted into in the device's ACPI declaration.