### PR TITLE
 Silicon/NXP: Remove EmuVariableRuntimeDxe

### DIFF
--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -178,6 +178,11 @@
 !endif
   iMX6UsbPhyLib|Silicon/NXP/iMX6Pkg/Library/iMX6UsbPhyLib/iMX6UsbPhyLib.inf
 
+  # VariableRuntimeDxe Requirements
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+  AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
+  VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
+
 [LibraryClasses.ARM]
   #
   # It is not possible to prevent the ARM compiler for generic intrinsic functions.
@@ -509,6 +514,11 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange|FALSE
   # GUID of the UI app
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
+
+  #
+  # Make VariableRuntimeDxe work at emulated non-volatile variable mode.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
 
 [PcdsPatchableInModule]
   # Console Resolution
@@ -997,7 +1007,7 @@
   }
 !endif
 
-MdeModulePkg/Universal/Variable/EmuRuntimeDxe/EmuVariableRuntimeDxe.inf
+MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
   # Applications
   MdeModulePkg/Application/HelloWorld/HelloWorld.inf

--- a/Silicon/NXP/iMX6Pkg/iMX6CommonFdf.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonFdf.inc
@@ -116,7 +116,7 @@
   }
 !endif
 
-INF MdeModulePkg/Universal/Variable/EmuRuntimeDxe/EmuVariableRuntimeDxe.inf
+INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
 [FV.FVMAIN_COMPACT]
 FvAlignment        = 8

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
@@ -202,6 +202,11 @@
   iMX7UsbPhyLib|Silicon/NXP/iMX7Pkg/Library/iMX7UsbPhyLib/iMX7UsbPhyLib.inf
 !endif
 
+  # VariableRuntimeDxe Requirements
+  SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
+  AuthVariableLib|MdeModulePkg/Library/AuthVariableLibNull/AuthVariableLibNull.inf
+  VarCheckLib|MdeModulePkg/Library/VarCheckLib/VarCheckLib.inf
+
 [LibraryClasses.ARM]
   #
   # It is not possible to prevent the ARM compiler for generic intrinsic functions.
@@ -460,6 +465,11 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdResetOnMemoryTypeInformationChange|FALSE
   # GUID of the UI app
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
+
+  #
+  # Make VariableRuntimeDxe work at emulated non-volatile variable mode.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
 
 [PcdsPatchableInModule]
   # Console Resolution
@@ -824,8 +834,7 @@
   }
 !endif
 
-MdeModulePkg/Universal/Variable/EmuRuntimeDxe/EmuVariableRuntimeDxe.inf
-
+MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
   # Applications
   MdeModulePkg/Application/HelloWorld/HelloWorld.inf

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonFdf.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonFdf.inc
@@ -195,7 +195,7 @@ READ_LOCK_STATUS   = TRUE
   }
 !endif
 
-INF MdeModulePkg/Universal/Variable/EmuRuntimeDxe/EmuVariableRuntimeDxe.inf
+INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
 
 [FV.FVMAIN_COMPACT]
 FvAlignment        = 8


### PR DESCRIPTION
This commit fixes a recent build break due to an update to 
tianocore/edk2 drivers.

Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=1323
Merge EmuVariable and Real variable driver.

The real variable driver has been updated to support emulated
variable NV mode and the EmuVariableRuntimeDxe was removed,
so use merged variable driver for emulated NV mode.