### PR TITLE
Fix LowSpeed USB Device Enumeration issue

### DIFF
--- a/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/Advantech/RSB4411_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -239,6 +241,8 @@ Device (USB1)
     Name (_HID, "FSCL000C")
     Name (_CID, "PNP0D20")
     Name (_UID, 0x1)
+    // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+    Name (_HRV, 0x1)
     // TODO: To enable USB to enter D3, set this to 3, and uncomment
     // the _DSW method below. _DSW will be called after the device enters D3.
     // It should enable an interrupt that should fire when a

--- a/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
@@ -19,7 +19,8 @@ Device(URS0)
 {
    Name(_HID, "PNP0C90")
    Name(_UID, 0x0)
-
+   // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+   Name (_HRV, 0x1)
    // URS requires device to at least be wake-able from D2 state
    // WDF also requires that _DSW (enable & disable wake ability) to be present
    Name(_S0W, 0x3)
@@ -269,6 +270,8 @@ Device (USB1)
     Name (_CID, "PNP0D20")
     Name (_UID, 0x1)
     Name (_S0W, 0x0)
+    // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+    Name (_HRV, 0x1)
 
     // USB Host controller registers
     OperationRegion (USBH, SystemMemory, 0x02184000, 0x1000)

--- a/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/BoundaryDevices/SabreLite_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
@@ -21,6 +21,7 @@ Device(URS0)
    Name(_UID, 0x0)
    // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
    Name (_HRV, 0x1)
+
    // URS requires device to at least be wake-able from D2 state
    // WDF also requires that _DSW (enable & disable wake ability) to be present
    Name(_S0W, 0x3)

--- a/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/NXP/Sabre_iMX6QP_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present

--- a/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/NXP/Sabre_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present

--- a/Platform/NXP/Sabre_iMX7D_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/NXP/Sabre_iMX7D_1GB/AcpiTables/Dsdt-Usb.asl
@@ -19,6 +19,8 @@ Device (USB2)
   Name (_HID, "NXP010C")
   Name (_CID, "PNP0D20")
   Name (_UID, 0x2)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
   Name (_S0W, 0x3)
   Method (_STA) {
     Return (0xf)

--- a/Platform/NXP/iMX6ULL_EVK_512MB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/NXP/iMX6ULL_EVK_512MB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device(URS0)
 {
   Name(_HID, "PNP0C90")
   Name(_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -269,6 +271,8 @@ Device (USBH)
     Name(_CID, "PNP0D20")
     Name(_UID, 0x0)
     Name(_S0W, 3)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)

--- a/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6DL_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -245,6 +247,8 @@ Device (USB1)
   Name (_CID, "PNP0D20")
   Name (_UID, 0x1)
   Name (_S0W, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)

--- a/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6D_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -245,6 +247,8 @@ Device (USB1)
   Name (_CID, "PNP0D20")
   Name (_UID, 0x1)
   Name (_S0W, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)

--- a/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6Q_2GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -245,6 +247,8 @@ Device (USB1)
   Name (_CID, "PNP0D20")
   Name (_UID, 0x1)
   Name (_S0W, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)

--- a/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/SolidRun/HummingBoardEdge_iMX6S_512MB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -245,6 +247,8 @@ Device (USB1)
   Name (_CID, "PNP0D20")
   Name (_UID, 0x1)
   Name (_S0W, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)

--- a/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
+++ b/Platform/VIA/VAB820_iMX6Q_1GB/AcpiTables/Dsdt-Usb.asl
@@ -18,6 +18,8 @@ Device (URS0)
 {
   Name (_HID, "PNP0C90")
   Name (_UID, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   // URS requires device to at least be wake-able from D2 state
   // WDF also requires that _DSW (enable & disable wake ability) to be present
@@ -245,6 +247,8 @@ Device (USB1)
   Name (_CID, "PNP0D20")
   Name (_UID, 0x1)
   Name (_S0W, 0x0)
+  // Hardware revision 1 supports integrated Transaction Translator (TT) in PortSC register
+  Name (_HRV, 0x1)
 
   Method (_STA) {
     Return (0xf)


### PR DESCRIPTION
NXP i.MX6 USB controllers support full and low speed USB devices through an
integrated Transaction Translator block. The Windows USBEHCI driver can be
enlightened to know about this TT block through a simple _HRV change in ACPI.
So let's advertise this TT block to Windows.

Signed-off-by: Christopher Co <christopher.co@microsoft.com>