### PR TITLE
Fix Build Break

### DIFF
--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -90,7 +90,6 @@
   #
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
   PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
-  NetLib|MdeModulePkg/Library/DxeNetLib/DxeNetLib.inf
 
   #
   # UEFI Services and Runtime
@@ -974,7 +973,6 @@
       NULL|ShellPkg/Library/UefiShellLevel1CommandsLib/UefiShellLevel1CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellLevel2CommandsLib/UefiShellLevel2CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellLevel3CommandsLib/UefiShellLevel3CommandsLib.inf
-      NULL|ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
       PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
 
     <PcdsFixedAtBuild>

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
@@ -111,7 +111,6 @@
   UefiUsbLib|MdePkg/Library/UefiUsbLib/UefiUsbLib.inf
 !endif
   PciLib|MdePkg/Library/BasePciLibCf8/BasePciLibCf8.inf
-  NetLib|MdeModulePkg/Library/DxeNetLib/DxeNetLib.inf
 
   #
   # UEFI Services and Runtime
@@ -800,7 +799,6 @@
       NULL|ShellPkg/Library/UefiShellLevel1CommandsLib/UefiShellLevel1CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellLevel2CommandsLib/UefiShellLevel2CommandsLib.inf
       NULL|ShellPkg/Library/UefiShellLevel3CommandsLib/UefiShellLevel3CommandsLib.inf
-      NULL|ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
       PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
 
     <PcdsFixedAtBuild>


### PR DESCRIPTION
Upstream edk2 core moved the NetLib package to a different location.
We don't expect to use networking in the UEFI environment so just remove it.