### PR TITLE
Update ci manifests

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -41,7 +41,8 @@ jobs:
 
     - script: |
         pushd ..
-        git clone --recursive https://github.com/tianocore/edk2
+        echo "EDK2 branch override is \"$(EDK2_BRANCH_OVERRIDE)\""
+        git clone --recursive https://github.com/tianocore/edk2 $(EDK2_BRANCH_OVERRIDE)
         git clone https://github.com/tianocore/edk2-libc.git
         git clone https://github.com/ms-iot/imx-iotcore.git
         popd

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
     - script: |
         pushd ..
         echo "EDK2 branch override is \"$(EDK2_BRANCH_OVERRIDE)\""
-        git clone --recursive https://github.com/tianocore/edk2 $(EDK2_BRANCH_OVERRIDE)
+        git clone --recursive https://github.com/ms-iot/edk2
         git clone https://github.com/tianocore/edk2-libc.git
         git clone https://github.com/ms-iot/imx-iotcore.git
         popd

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -60,16 +60,4 @@ jobs:
         make uefi CROSS_COMPILE=$(Build.SourcesDirectory)/gcc-linaro-6.4.1-2017.11-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
       displayName: Build UEFI
 
-    - script: |
-        pushd ../imx-edk2-platforms
-        python3 ../imx-iotcore/ci/build_cgmanifest.py ci/cgmanifest_template.json
-        cat cgmanifest.json
-        popd
-
-        pushd ../edk2
-        python3 ../imx-iotcore/ci/build_cgmanifest.py
-        cat cgmanifest.json
-        popd
-      displayName: Generate dynamic Component Governance cgmanifest.json
-      
     - task: ComponentGovernanceComponentDetection@0

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -41,7 +41,6 @@ jobs:
 
     - script: |
         pushd ..
-        echo "EDK2 branch override is \"$(EDK2_BRANCH_OVERRIDE)\""
         git clone --recursive https://github.com/ms-iot/edk2
         git clone https://github.com/tianocore/edk2-libc.git
         git clone https://github.com/ms-iot/imx-iotcore.git

--- a/ci/cgmanifest.json
+++ b/ci/cgmanifest.json
@@ -31,15 +31,6 @@
             "component": {
                 "type": "git",
                 "git": {
-                    "repositoryUrl": "https://github.com/openssl/openssl",
-                    "commitHash": "74f2d9c1ec5f5510e1d3da5a9f03c28df0977762"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
                     "repositoryUrl": "https://github.com/ms-iot/optee_os",
                     "commitHash": "bc454ea594eefeed0ffb4baa1fdc09f47cdc1704"
                 }

--- a/ci/cgmanifest.json
+++ b/ci/cgmanifest.json
@@ -5,7 +5,7 @@
                 "type": "git",
                 "git": {
                     "repositoryUrl": "https://github.com/tianocore/edk2",
-                    "commitHash": "5a9e23ceb991f3bd0eea74d6b67f9102f65ea6bc"
+                    "commitHash": "8594c2073cdb1065e60f01e9b099918c5e839212"
                 }
             }
         },

--- a/ci/cgmanifest.json
+++ b/ci/cgmanifest.json
@@ -4,7 +4,7 @@
             "component": {
                 "type": "git",
                 "git": {
-                    "repositoryUrl": "https://github.com/tianocore/edk2",
+                    "repositoryUrl": "https://github.com/ms-iot/edk2",
                     "commitHash": "8594c2073cdb1065e60f01e9b099918c5e839212"
                 }
             }

--- a/ci/cgmanifest.json
+++ b/ci/cgmanifest.json
@@ -1,0 +1,77 @@
+{
+    "Registrations": [
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/tianocore/edk2",
+                    "commitHash": "5a9e23ceb991f3bd0eea74d6b67f9102f65ea6bc"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/tianocore/edk2-libc",
+                    "commitHash": "61687168fe02ac4d933a36c9145fdd242ac424d1"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/MSRSec",
+                    "commitHash": "3c0db43ceaa0da74688b138bf643905c2d374a00"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/openssl/openssl",
+                    "commitHash": "74f2d9c1ec5f5510e1d3da5a9f03c28df0977762"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ms-iot/optee_os",
+                    "commitHash": "bc454ea594eefeed0ffb4baa1fdc09f47cdc1704"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/ms-tpm-20-ref.git",
+                    "commitHash": "6cb570e90317c7927a0c6da86a27777376a9a433"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/openssl/openssl.git",
+                    "commitHash": "3d753b0cefaa7e3d4b5d12d7805b20fabff1f385"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/wolfSSL/wolfssl.git",
+                    "commitHash": "74ebf510a3d73e98767eac26082eabdc84e19d31"
+                }
+            }
+        }
+    ],
+    "Version": 1
+}

--- a/ci/cgmanifest_template.json
+++ b/ci/cgmanifest_template.json
@@ -4,7 +4,7 @@
             "component": {
                 "type": "git",
                 "git": {
-                    "repositoryUrl": "https://github.com/tianocore/edk2",
+                    "repositoryUrl": "https://github.com/ms-iot/edk2",
                     "branch": "master"
                 }
             }

--- a/ci/cgmanifest_template.json
+++ b/ci/cgmanifest_template.json
@@ -17,6 +17,15 @@
                     "branch": "master"
                 }
             }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/Microsoft/MSRSec",
+                    "branch": "master"
+                }
+            }
         }
     ],
     "Version": 1


### PR DESCRIPTION
Update CG manifests to be semi-static instead of dynamicly generated to help internal tooling function better.

Allow for a specific branch of EDK2 to be used.