### PR TITLE
Fix build break - remove dependency on edk2 stdlib package

### DIFF
--- a/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.c
+++ b/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.c
@@ -17,6 +17,7 @@
 #include <Guid/AuthVarTestFfs.h>
 #include <Guid/GlobalVariable.h>
 #include <Guid/ImageAuthentication.h>
+#include <Library/BaseCryptLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DxeServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -26,7 +27,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Protocol/ShellParameters.h>
 
-#include "EdkTest.h"
+#include <EdkTest.h>
 
 MODULE ("UEFI authenticated variables functional tests");
 
@@ -59,22 +60,6 @@ AuthVarInfo mSecureBootVariables[] = {
     EFI_KEY_EXCHANGE_KEY_NAME
   }
 };
-
-VOID
-RandomBytes (
-  IN UINTN    BufferSize,
-  OUT UINT8   *Buffer
-  )
-{
-  UINTN Index;
-
-  ASSERT (Buffer != NULL);
-
-  for (Index = 0; Index < BufferSize; ++Index) {
-    // Generate random number between 0 and 255 inclusive
-    Buffer[Index] = (UINT8) (rand() % 256);
-  }
-}
 
 VOID
 VerifyAreEqualBytes (
@@ -669,7 +654,7 @@ VerifyNameHandling (
 
   mImageData = AllocateZeroPool (DataSize);
   VERIFY_IS_NOT_NULL (mImageData);
-  RandomBytes (DataSize, mImageData);
+  RandomBytes ((UINT8 *)mImageData, DataSize);
   
   mActualImageData = AllocatePool(DataSize);
   VERIFY_IS_NOT_NULL(mActualImageData);
@@ -800,7 +785,7 @@ VerifyNameHandling (
     mImageData = NULL;
     mImageData = AllocateZeroPool (DataSize);
     VERIFY_IS_NOT_NULL (mImageData);
-    RandomBytes (DataSize, mImageData);
+    RandomBytes ((UINT8 *)mImageData, DataSize);
 
     // Make sure none of the other variables are confused with
     // this one.
@@ -883,7 +868,7 @@ VerifyQuery (
 
     mImageData = AllocateZeroPool (LargerVariableSize);
     VERIFY_IS_NOT_NULL (mImageData);
-    RandomBytes (LargerVariableSize, mImageData);
+    RandomBytes ((UINT8 *)mImageData, LargerVariableSize);
     mActualImageData = AllocatePool(LargerVariableSize);
     VERIFY_IS_NOT_NULL(mActualImageData);
 
@@ -991,7 +976,7 @@ VerifyOverflow (
 
   mImageData = AllocateZeroPool (LargerVariableSize);
   VERIFY_IS_NOT_NULL (mImageData);
-  RandomBytes (LargerVariableSize, mImageData);
+  RandomBytes ((UINT8 *)mImageData, LargerVariableSize);
 
   for(OverflowCount = 0; OverflowCount < OverflowGoal; OverflowCount++)
   {
@@ -1127,7 +1112,7 @@ TestInvalidAuthVars (
   mImageData = AllocateZeroPool (ImageSize);
   VERIFY_IS_NOT_NULL (mImageData);
 
-  RandomBytes (ImageSize, mImageData);
+  RandomBytes ((UINT8 *)mImageData, ImageSize);
 
   LOG_COMMENT ("Verifying garbage authenticated variable %s\n",\
                 mSecureBootVariables[0].VariableName
@@ -1174,7 +1159,7 @@ TestValidNonVolatileVars (
     ImageSize = BufferSizes[Idx];
     mImageData = AllocateZeroPool (ImageSize);
     VERIFY_IS_NOT_NULL (mImageData);
-    RandomBytes (ImageSize, mImageData);
+    RandomBytes ((UINT8 *)mImageData, ImageSize);
 
     UnicodeSPrint (TestVariableName,
                    sizeof(TestVariableName),
@@ -1235,6 +1220,7 @@ TestSetup (
   )
 {
   SET_LOG_LEVEL(TestLogComment);
+  RandomSeed (NULL, 0);
   return TRUE;
 }
 

--- a/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+++ b/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
@@ -28,7 +28,7 @@
   Platform/Microsoft/MsPkg.dec
   SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec	
+  StdLib/StdLib.dec
 
 [LibraryClasses]
   BaseLib

--- a/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+++ b/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
@@ -28,13 +28,12 @@
   Platform/Microsoft/MsPkg.dec
   SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
+  BaseCryptLib
   BaseLib
   DebugLib
   DxeServicesLib
-  LibC
   MemoryAllocationLib
   UefiApplicationEntryPoint
   UefiBootServicesTableLib

--- a/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+++ b/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
@@ -28,11 +28,13 @@
   Platform/Microsoft/MsPkg.dec
   SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
+  StdLib/StdLib.dec	
 
 [LibraryClasses]
   BaseLib
   DebugLib
   DxeServicesLib
+  LibC
   MemoryAllocationLib
   UefiApplicationEntryPoint
   UefiBootServicesTableLib

--- a/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+++ b/Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
@@ -28,15 +28,13 @@
   Platform/Microsoft/MsPkg.dec
   SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
   BaseLib
   DebugLib
   DxeServicesLib
-  LibC
-  LibStdio
   MemoryAllocationLib
+  UefiApplicationEntryPoint
   UefiBootServicesTableLib
   UefiLib
 

--- a/Platform/Microsoft/Application/StorageTest/StorageTest.c
+++ b/Platform/Microsoft/Application/StorageTest/StorageTest.c
@@ -12,7 +12,8 @@
 *
 **/
 
-#include "EdkTest.h"
+#include <Uefi.h>
+#include <Library/BaseCryptLib.h>
 #include <Library/DebugLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -21,14 +22,7 @@
 #include <Library/UefiLib.h>
 #include <Protocol/ShellParameters.h>
 #include <Protocol/SimpleFileSystem.h>
-#include <setjmp.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <Uefi.h>
-#include <wchar.h>
+#include <EdkTest.h>
 
 MODULE ("Storage FAT media functional tests");
 
@@ -45,20 +39,14 @@ EFI_FILE_PROTOCOL *File;
 UINT8 *WriteBuffer;
 UINT8 *ReadBuffer;
 
-VOID
-RandomBytes (
-  IN UINTN    BufferSize,
-  OUT UINT8   *Buffer
+UINT32
+Rand (
+  VOID
   )
 {
-  UINTN Index;
-
-  ASSERT (Buffer != NULL);
-
-  for (Index = 0; Index < BufferSize; ++Index) {
-    // Generate random number between 0 and 255 inclusive
-    Buffer[Index] = (UINT8) (rand() % 256);
-  }
+  UINT32 Value;
+  RandomBytes ((UINT8 *)&Value, sizeof (Value));
+  return Value;
 }
 
 VOID
@@ -126,12 +114,12 @@ TestRandomWriteRead (
 
     for (j = 0; j < 100 / (i + 1); ++j) {
       SET_LOG_LEVEL (TestLogError);
-      FilePos = (rand() % SIZE_1KB);
+      FilePos = (Rand() % SIZE_1KB);
       VERIFY_SUCCEEDED (File->SetPosition (File, FilePos));
       VERIFY_SUCCEEDED (File->GetPosition (File, &ActualFilePos));
       VERIFY_ARE_EQUAL (UINT64, FilePos, ActualFilePos);
 
-      RandomBytes (BufferSizes[i], WriteBuffer);
+      RandomBytes (WriteBuffer, BufferSizes[i]);
 
       WriteBufferSize = BufferSizes[i];
       VERIFY_SUCCEEDED (File->Write (File, &WriteBufferSize, WriteBuffer));
@@ -170,6 +158,7 @@ TestSetup (
   File = NULL;
   WriteBuffer = NULL;
   ReadBuffer = NULL;
+  RandomSeed (NULL, 0);
   return TRUE;
 }
 

--- a/Platform/Microsoft/Application/StorageTest/StorageTest.inf
+++ b/Platform/Microsoft/Application/StorageTest/StorageTest.inf
@@ -25,9 +25,11 @@
   MdePkg/MdePkg.dec
   Platform/Microsoft/MsPkg.dec
   ShellPkg/ShellPkg.dec
+  StdLib/StdLib.dec	
 
 [LibraryClasses]
   DebugLib
+  LibC
   UefiApplicationEntryPoint
   UefiLib
 

--- a/Platform/Microsoft/Application/StorageTest/StorageTest.inf
+++ b/Platform/Microsoft/Application/StorageTest/StorageTest.inf
@@ -25,10 +25,11 @@
   MdePkg/MdePkg.dec
   Platform/Microsoft/MsPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
   DebugLib
-  LibC
-  LibStdio
+  UefiApplicationEntryPoint
   UefiLib
+
+[Protocols]
+  gEfiShellParametersProtocolGuid

--- a/Platform/Microsoft/Application/StorageTest/StorageTest.inf
+++ b/Platform/Microsoft/Application/StorageTest/StorageTest.inf
@@ -22,14 +22,14 @@
   StorageTest.c
 
 [Packages]
+  CryptoPkg/CryptoPkg.dec
   MdePkg/MdePkg.dec
   Platform/Microsoft/MsPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
+  BaseCryptLib
   DebugLib
-  LibC
   UefiApplicationEntryPoint
   UefiLib
 

--- a/Platform/Microsoft/Application/StorageTest/StorageTest.inf
+++ b/Platform/Microsoft/Application/StorageTest/StorageTest.inf
@@ -25,7 +25,7 @@
   MdePkg/MdePkg.dec
   Platform/Microsoft/MsPkg.dec
   ShellPkg/ShellPkg.dec
-  StdLib/StdLib.dec	
+  StdLib/StdLib.dec
 
 [LibraryClasses]
   DebugLib

--- a/Platform/Microsoft/Include/EdkTest.h
+++ b/Platform/Microsoft/Include/EdkTest.h
@@ -20,10 +20,6 @@
 #include <Library/DebugLib.h>
 #include <Library/TimerLib.h>
 
-#include <setjmp.h>
-#include <stddef.h>
-#include <stdlib.h>
-
 #ifndef C_ASSERT
 #define C_ASSERT(e) _Static_assert(e, #e)
 #endif // C_ASSERT

--- a/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.c
+++ b/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.c
@@ -49,8 +49,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <Guid/ImageAuthentication.h>
 #include <Guid/OpteeTrustedAppGuids.h>
 
-#include <limits.h>
-
 /*
 Performance Tokens
 */

--- a/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.inf
@@ -39,7 +39,6 @@
   MdeModulePkg/MdeModulePkg.dec
   SecurityPkg/SecurityPkg.dec
   Platform/Microsoft/OpteeClientPkg/OpteeClientPkg.dec
-  StdLib/StdLib.dec
   Platform/Microsoft/MsPkg.dec
 
 [LibraryClasses]

--- a/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Drivers/AuthVarOpteeRuntimeDxe/AuthVarsDxe.inf
@@ -91,4 +91,7 @@
   gMsPkgTokenSpaceGuid.PcdStorageMediaPartitionDevicePath
 
 [Depex]
-TRUE
+  TRUE
+
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -ffreestanding -Wno-unused-label

--- a/Platform/Microsoft/OpteeClientPkg/Include/Library/tee_client_api.h
+++ b/Platform/Microsoft/OpteeClientPkg/Include/Library/tee_client_api.h
@@ -31,7 +31,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-//#include <limits.h>
 
 /*
  * Defines the number of available memory references in an open session or

--- a/Platform/Microsoft/OpteeClientPkg/Include/Library/tee_client_api.h
+++ b/Platform/Microsoft/OpteeClientPkg/Include/Library/tee_client_api.h
@@ -31,7 +31,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <limits.h>
+//#include <limits.h>
 
 /*
  * Defines the number of available memory references in an open session or

--- a/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/Arm/OpteeClientRPC.c
+++ b/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/Arm/OpteeClientRPC.c
@@ -41,7 +41,6 @@
 #include <Library/PerformanceLib.h>
 #include <Library/tee_client_api.h>
 #include <Protocol/RpmbIo.h>
-#include <string.h>
 
 #include "OpteeClientDefs.h"
 #include "OpteeClientRPC.h"
@@ -445,7 +444,7 @@ OpteeRpcCmdRpmb (
       RpmbDevInfo = (rpmb_dev_info_t *)(UINTN) MsgParam[1].u.tmem.buf_ptr;
 
       C_ASSERT (sizeof(RpmbDevInfo->cid) == sizeof(RpmbProtocol->Cid));
-      memcpy (RpmbDevInfo->cid, RpmbProtocol->Cid, RPMB_EMMC_CID_SIZE);
+      CopyMem (RpmbDevInfo->cid, RpmbProtocol->Cid, RPMB_EMMC_CID_SIZE);
       RpmbDevInfo->rel_wr_sec_c = (uint8_t) RpmbProtocol->ReliableSectorCount;
       RpmbDevInfo->rpmb_size_mult = (uint8_t) RpmbProtocol->RpmbSizeMult;
       RpmbDevInfo->ret_code = RPMB_CMD_GET_DEV_INFO_RET_OK;

--- a/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/OpteeClientApiLib.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/OpteeClientApiLib.inf
@@ -39,7 +39,6 @@
   ArmPkg/ArmPkg.dec
   Platform/Microsoft/OpteeClientPkg/OpteeClientPkg.dec
   Platform/Microsoft/MsPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
   BaseLib

--- a/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/OpteeClientApiLib.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Library/OpteeClientApiLib/OpteeClientApiLib.inf
@@ -58,3 +58,5 @@
 [Protocols]
   gEfiRpmbIoProtocolGuid
 
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -ffreestanding -Wno-unused-label

--- a/Platform/Microsoft/OpteeClientPkg/Library/Tpm2DeviceLibOptee/Tpm2DeviceLibOptee.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Library/Tpm2DeviceLibOptee/Tpm2DeviceLibOptee.inf
@@ -51,3 +51,6 @@
 
 [Depex]
   TRUE
+
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -ffreestanding -Wno-unused-label

--- a/Platform/Microsoft/OpteeClientPkg/Library/Tpm2DeviceLibOptee/Tpm2DeviceLibOptee.inf
+++ b/Platform/Microsoft/OpteeClientPkg/Library/Tpm2DeviceLibOptee/Tpm2DeviceLibOptee.inf
@@ -32,7 +32,6 @@
   SecurityPkg/SecurityPkg.dec
   Platform/Microsoft/OpteeClientPkg/OpteeClientPkg.dec
   Platform/Microsoft/MsPkg.dec
-  StdLib/StdLib.dec
 
 [LibraryClasses]
   BaseLib

--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -133,6 +133,7 @@
   #
   ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+  FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
 
   #
   # Serial, Console and Debugging
@@ -1018,20 +1019,7 @@
 !endif
 
   # Applications
-  MdeModulePkg/Application/HelloWorld/HelloWorld.inf
-  Silicon/NXP/iMX6Pkg/Application/ImxClkPwr/ImxClkPwr.inf
-
 !if $(CONFIG_EDK_TESTS) == TRUE
   Platform/Microsoft/Application/StorageTest/StorageTest.inf
   Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
 !endif
-
-!if $(CONFIG_OPTEE) == TRUE
-  Platform/Microsoft/OpteeClientPkg/Application/OpteeClientApiTest/OpteeClientApiTest.inf
-  #SecurityPkg/Application/VariableAuthTestDxe/VariableAuthTestDxe.inf
-!endif
-#
-# Boilerplate for compiling UEFI applications and UEFI drivers with the
-# standard library.
-#
-!include StdLib/StdLib.inc

--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -1021,54 +1021,7 @@
   #
   # Applications
   #
-  # For each application, you can include stdlib libraries from StdLib/StdLib.inc.
-  # This stdlib implementation is only intended for UEFI Applications. It
-  # modifies the compiler's CC_FLAGS to ignore all other stdlib implementations
-  # which could break firmware builds if the StdLib.inc is included haphazardly.
-  # This stdlib is located in tianocore/edk2-libc and must be in your
-  # PACKAGES_PATH environment variable during application build.
-  #
 !if $(CONFIG_EDK_TESTS) == TRUE
-  Platform/Microsoft/Application/StorageTest/StorageTest.inf {
-    <LibraryClasses>
-    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
-    LibC|StdLib/LibC/LibC.inf
-    LibCType|StdLib/LibC/Ctype/Ctype.inf
-    LibLocale|StdLib/LibC/Locale/Locale.inf
-    LibSignal|StdLib/LibC/Signal/Signal.inf
-    LibStdio|StdLib/LibC/Stdio/Stdio.inf
-    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
-    LibString|StdLib/LibC/String/String.inf
-    LibTime|StdLib/LibC/Time/Time.inf
-    LibUefi|StdLib/LibC/Uefi/Uefi.inf
-    LibWchar|StdLib/LibC/Wchar/Wchar.inf
-    LibGen|StdLib/PosixLib/Gen/LibGen.inf
-    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
-    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
-    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
-    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
-    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
-    NULL|StdLib/LibC/Softfloat/Softfloat.inf
-  }
-  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf{
-    <LibraryClasses>
-    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
-    LibC|StdLib/LibC/LibC.inf
-    LibCType|StdLib/LibC/Ctype/Ctype.inf
-    LibLocale|StdLib/LibC/Locale/Locale.inf
-    LibSignal|StdLib/LibC/Signal/Signal.inf
-    LibStdio|StdLib/LibC/Stdio/Stdio.inf
-    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
-    LibString|StdLib/LibC/String/String.inf
-    LibTime|StdLib/LibC/Time/Time.inf
-    LibUefi|StdLib/LibC/Uefi/Uefi.inf
-    LibWchar|StdLib/LibC/Wchar/Wchar.inf
-    LibGen|StdLib/PosixLib/Gen/LibGen.inf
-    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
-    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
-    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
-    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
-    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
-    NULL|StdLib/LibC/Softfloat/Softfloat.inf
-  }
+  Platform/Microsoft/Application/StorageTest/StorageTest.inf 
+  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
 !endif

--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -1018,7 +1018,16 @@
   }
 !endif
 
+  #
   # Applications
+  #
+  # For each application, you can include stdlib libraries from StdLib/StdLib.inc.
+  # This stdlib implementation is only intended for UEFI Applications. It
+  # modifies the compiler's CC_FLAGS to ignore all other stdlib implementations
+  # which could break firmware builds if the StdLib.inc is included haphazardly.
+  # This stdlib is located in tianocore/edk2-libc and must be in your
+  # PACKAGES_PATH environment variable during application build.
+  #
 !if $(CONFIG_EDK_TESTS) == TRUE
   Platform/Microsoft/Application/StorageTest/StorageTest.inf {
     <LibraryClasses>

--- a/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
+++ b/Silicon/NXP/iMX6Pkg/iMX6CommonDsc.inc
@@ -1020,6 +1020,46 @@
 
   # Applications
 !if $(CONFIG_EDK_TESTS) == TRUE
-  Platform/Microsoft/Application/StorageTest/StorageTest.inf
-  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+  Platform/Microsoft/Application/StorageTest/StorageTest.inf {
+    <LibraryClasses>
+    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
+    LibC|StdLib/LibC/LibC.inf
+    LibCType|StdLib/LibC/Ctype/Ctype.inf
+    LibLocale|StdLib/LibC/Locale/Locale.inf
+    LibSignal|StdLib/LibC/Signal/Signal.inf
+    LibStdio|StdLib/LibC/Stdio/Stdio.inf
+    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
+    LibString|StdLib/LibC/String/String.inf
+    LibTime|StdLib/LibC/Time/Time.inf
+    LibUefi|StdLib/LibC/Uefi/Uefi.inf
+    LibWchar|StdLib/LibC/Wchar/Wchar.inf
+    LibGen|StdLib/PosixLib/Gen/LibGen.inf
+    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
+    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
+    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
+    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
+    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
+    NULL|StdLib/LibC/Softfloat/Softfloat.inf
+  }
+  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf{
+    <LibraryClasses>
+    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
+    LibC|StdLib/LibC/LibC.inf
+    LibCType|StdLib/LibC/Ctype/Ctype.inf
+    LibLocale|StdLib/LibC/Locale/Locale.inf
+    LibSignal|StdLib/LibC/Signal/Signal.inf
+    LibStdio|StdLib/LibC/Stdio/Stdio.inf
+    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
+    LibString|StdLib/LibC/String/String.inf
+    LibTime|StdLib/LibC/Time/Time.inf
+    LibUefi|StdLib/LibC/Uefi/Uefi.inf
+    LibWchar|StdLib/LibC/Wchar/Wchar.inf
+    LibGen|StdLib/PosixLib/Gen/LibGen.inf
+    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
+    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
+    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
+    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
+    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
+    NULL|StdLib/LibC/Softfloat/Softfloat.inf
+  }
 !endif

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
@@ -839,7 +839,16 @@
   }
 !endif
 
+  #
   # Applications
+  #
+  # For each application, you can include stdlib libraries from StdLib/StdLib.inc.
+  # This stdlib implementation is only intended for UEFI Applications. It
+  # modifies the compiler's CC_FLAGS to ignore all other stdlib implementations
+  # which could break firmware builds if the StdLib.inc is included haphazardly.
+  # This stdlib is located in tianocore/edk2-libc and must be in your
+  # PACKAGES_PATH environment variable during application build.
+  #
 !if $(CONFIG_EDK_TESTS) == TRUE
   Platform/Microsoft/Application/StorageTest/StorageTest.inf {
     <LibraryClasses>

--- a/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
+++ b/Silicon/NXP/iMX7Pkg/iMX7CommonDsc.inc
@@ -155,6 +155,7 @@
   #
   ShellLib|ShellPkg/Library/UefiShellLib/UefiShellLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+  FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
 
   #
   # Serial, Console and Debugging
@@ -839,21 +840,47 @@
 !endif
 
   # Applications
-  MdeModulePkg/Application/HelloWorld/HelloWorld.inf
-  #Platform/Microsoft/Application/StorageTest/StorageTest.inf
-#  Silicon/NXP/iMX7Pkg/Application/ImxClkPwr/ImxClkPwr.inf
-
 !if $(CONFIG_EDK_TESTS) == TRUE
-  Platform/Microsoft/Application/StorageTest/StorageTest.inf
-  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf
+  Platform/Microsoft/Application/StorageTest/StorageTest.inf {
+    <LibraryClasses>
+    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
+    LibC|StdLib/LibC/LibC.inf
+    LibCType|StdLib/LibC/Ctype/Ctype.inf
+    LibLocale|StdLib/LibC/Locale/Locale.inf
+    LibSignal|StdLib/LibC/Signal/Signal.inf
+    LibStdio|StdLib/LibC/Stdio/Stdio.inf
+    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
+    LibString|StdLib/LibC/String/String.inf
+    LibTime|StdLib/LibC/Time/Time.inf
+    LibUefi|StdLib/LibC/Uefi/Uefi.inf
+    LibWchar|StdLib/LibC/Wchar/Wchar.inf
+    LibGen|StdLib/PosixLib/Gen/LibGen.inf
+    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
+    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
+    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
+    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
+    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
+    NULL|StdLib/LibC/Softfloat/Softfloat.inf
+  }
+  Platform/Microsoft/Application/AuthVarTest/AuthVarTest.inf{
+    <LibraryClasses>
+    ShellCEntryLib|ShellPkg/Library/UefiShellCEntryLib/UefiShellCEntryLib.inf
+    LibC|StdLib/LibC/LibC.inf
+    LibCType|StdLib/LibC/Ctype/Ctype.inf
+    LibLocale|StdLib/LibC/Locale/Locale.inf
+    LibSignal|StdLib/LibC/Signal/Signal.inf
+    LibStdio|StdLib/LibC/Stdio/Stdio.inf
+    LibStdLib|StdLib/LibC/StdLib/StdLib.inf
+    LibString|StdLib/LibC/String/String.inf
+    LibTime|StdLib/LibC/Time/Time.inf
+    LibUefi|StdLib/LibC/Uefi/Uefi.inf
+    LibWchar|StdLib/LibC/Wchar/Wchar.inf
+    LibGen|StdLib/PosixLib/Gen/LibGen.inf
+    LibIIO|StdLib/LibC/Uefi/InteractiveIO/IIO.inf
+    LibContainer|StdLib/LibC/Containers/ContainerLib.inf
+    LibGdtoa|StdLib/LibC/gdtoa/gdtoa.inf
+    DevConsole|StdLib/LibC/Uefi/Devices/daConsole.inf
+    DevUtility|StdLib/LibC/Uefi/Devices/daUtility.inf
+    NULL|StdLib/LibC/Softfloat/Softfloat.inf
+  }
 !endif
-
-  Platform/Microsoft/OpteeClientPkg/Application/OpteeClientApiTest/OpteeClientApiTest.inf
-  #SecurityPkg/Application/VariableAuthTestDxe/VariableAuthTestDxe.inf
-
-#
-# Boilerplate for compiling UEFI applications and UEFI drivers with the
-# standard library.
-#
-!include StdLib/StdLib.inc
-


### PR DESCRIPTION
Originally, we always include Edk2's StdLib.inc into our build. This
lib is only meant to be included to build UEFI applications but for some
reason we decided to have it included in all components (PEI, DXE, etc).
Including this file sets the -nostdinc flag, presumably to avoid
collisions with the toolchain's stdlib.

edk2 recently updated their ArmPkg/ArmSoftFloatLib library to use a
modern implementation. This implementation requires stdint.h and
stdbool.h and expects to pull these from the toolchain and not
edk2's stdlib implementation since this is a library and not an application.

We shouldn't be using edk2's StdLib for building non-application
components so let's remove it.

limits.h and string.h end up including gnu/stubs-soft.h which
is not included in the arm-linux-gnueabihf toolchain. Edk2 expects to
be built with float=soft yet the officially supported toolchain targets
hardfloat. We don't actually use these functions in our code so just
remove the headers.

Signed-off-by: Christopher Co <christopher.co@microsoft.com>